### PR TITLE
Clarify instructions on education engineer assignment

### DIFF
--- a/education-engineer/assignment.md
+++ b/education-engineer/assignment.md
@@ -32,4 +32,4 @@ When editing:
 ### Assumptions: 
 - The audience has none to minimal experience with Terraform.
 
-Once you have completed the assignment, send a link to your PR to the recruiter.
+Once you have completed the assignment, send a link to your PR to the hiring manager.

--- a/education-engineer/assignment.md
+++ b/education-engineer/assignment.md
@@ -8,7 +8,6 @@ Please take the time to carefully review the [writing style guide](../styling-gu
 
 ## Instructions
 
-
 Update the [sample text](terraform-getting-started.md) to follow the provided [writing style guide](../styling-guide-snippet.md) and
 [guide template](../guide-template.md).
 
@@ -20,7 +19,7 @@ To complete the assignment:
 - Create a new branch and update the sample text to satisfy the style guide.
 - Create a pull request for your proposed changes to the text. Do not merge the pull request.
 
-**NOTE: DO NOT FORK THE PROJECT.** Make a copy of all files, create a fresh repository, and open a pull request against your own project.
+**NOTE: DO NOT BRANCH OR FORK THE PROJECT.** Make a copy of all files, create a fresh repository, and open a pull request against your own project.
 
 When editing:
 - Identify and fix any spelling or grammar mistakes.
@@ -33,4 +32,4 @@ When editing:
 ### Assumptions: 
 - The audience has none to minimal experience with Terraform.
 
-Once you have completed the assignment, send a link to your PR to the HashiCorp recruiter.
+Once you have completed the assignment, send a link to your PR to the recruiter.

--- a/education-engineer/assignment.md
+++ b/education-engineer/assignment.md
@@ -1,5 +1,7 @@
 ## Overview 
 
+As an Education Engineer, you will be responsible for creating and editing tutorials and other documentation.  You will do this work in collaboration with other education engineers, technical writers, product teams, and other stakeholders.
+
 This technical writing and editing project is part of your interview. It is designed to take between 1.5 - 2 hours.
 
 Please take the time to carefully review the [writing style guide](../styling-guide-snippet.md) and the [guide template](../guide-template.md) before getting started.
@@ -10,7 +12,7 @@ Please take the time to carefully review the [writing style guide](../styling-gu
 Update the [sample text](terraform-getting-started.md) to follow the provided [writing style guide](../styling-guide-snippet.md) and
 [guide template](../guide-template.md).
 
-**Any changes that you think will improve the text and explain the concepts better are welcome**. If anything in the text does not match your opinion on a best practice, feel free to correct the meaning of the text. You may link to existing resources created by HashiCorp or the community, but do not plagiarize content from HashiCorp tutorials or documentation. 
+**Any changes that you think will improve the text and explain the concepts better are welcome**. If anything in the text does not match your opinion on a best practice, feel free to correct the meaning of the text. You may link to existing resources created by HashiCorp or the community, but do not plagiarize content from HashiCorp tutorials or documentation. Commentary explaining your changes or providing feedback to the original authors is also welcome.
 
 To complete the assignment:
 - Create a new, public GitHub repository for your submission (do not fork this repository). Make sure the repository is publicly accessible so we can review your submission.


### PR DESCRIPTION
Minor clarifications on the Education Engineer assignment:
- Adds an overview of the role as context
- Mentions that explanations/feedback are welcome
- Disallows branching
- No longer a HashiCorp recruiter